### PR TITLE
Implement Applicability

### DIFF
--- a/lift-tools-framework.cabal
+++ b/lift-tools-framework.cabal
@@ -20,11 +20,16 @@ library
     exposed-modules:    Lift.ToolIntegration
                         Lift.ToolIntegration.Applicable
                         Lift.ToolIntegration.Cli
+                        Lift.ToolIntegration.Project
                         Lift.ToolIntegration.ToolResults
     build-depends:      base ^>=4.14.1.0
                       , relude >= 1.0.0 && < 1.1
                       , aeson >= 1.5.6 && < 1.6
+                      , directory >= 1.3.6 && < 1.4
+                      , filepath >= 1.4.2 && < 1.5 
+                      , HMock >= 0.3.0 && < 0.4
                       , optparse-applicative >= 0.16.1 && < 0.17
+                      , regex >= 1.1.0 && < 1.2
     hs-source-dirs:     src
     default-language:   Haskell2010
     ghc-options:        -threaded -Wall -Werror -rtsopts
@@ -36,12 +41,18 @@ test-suite lift-tools-framework-tests
     main-is:            Spec.hs
     other-modules:      Lift.ToolIntegrationSpec
                         Lift.ToolIntegration.ApplicableSpec
+                        Lift.ToolIntegration.ProjectSpec
+                        Mock.Project
     build-depends:      base ^>=4.14.1.0
                       , lift-tools-framework
                       , relude >= 1.0.0 && < 1.1
                       , aeson >= 1.5.6 && < 1.6
+                      , directory >= 1.3.6 && < 1.4
+                      , HMock
                       , hspec
+                      , temporary
                       , raw-strings-qq
+                      , regex >= 1.1.0 && < 1.2
     hs-source-dirs:     test
     default-language:   Haskell2010
     ghc-options:        -threaded -Wall -Werror -rtsopts

--- a/src/Lift/ToolIntegration/Project.hs
+++ b/src/Lift/ToolIntegration/Project.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE FlexibleInstances #-}
+module Lift.ToolIntegration.Project
+  ( MonadProject(..)
+  , ProjectContext(..)
+  ) where
+
+import System.Directory
+import System.FilePath.Posix (makeRelative)
+import Relude
+
+class (Monad m) => MonadProject m where
+  listFiles :: m [Text]
+
+instance MonadProject IO where
+  listFiles = error "TODO: implement"
+
+data ProjectContext = ProjectContext
+  { projectRoot :: Text
+  }
+
+instance (MonadIO m) => MonadProject (ReaderT ProjectContext m) where
+  listFiles = do
+    folder <- asks projectRoot
+    let f = toString folder
+    allFiles <- listAllFiles f
+    pure $ toText . makeRelative f <$> allFiles
+
+listAllFiles :: (MonadIO m) => String -> m [String]
+listAllFiles folder = do
+  liftIO $ putStrLn ("listing: " <> folder)
+  contents <- liftIO $ listDirectory (toString folder)
+  (folders, files) <- liftIO $ partitionFiles (mappend (folder <> "/") <$> contents)
+  subFiles <- join <$> traverse listAllFiles folders
+  pure $ files <> subFiles
+  where
+    partitionFiles :: [String] -> IO ([String], [String])
+    partitionFiles = foldlM partitionFile ([], [])
+    partitionFile :: ([String], [String]) -> String -> IO ([String], [String])
+    partitionFile (folders, files) file = do
+      isFile <- doesFileExist file
+      isFolder <- doesDirectoryExist file
+      pure $ case (isFolder, isFile) of
+        (True, False) -> (file : folders, files)
+        (False, True) -> (folders , file : files)
+        (_, _) -> (folders, files)

--- a/test/Lift/ToolIntegration/ApplicableSpec.hs
+++ b/test/Lift/ToolIntegration/ApplicableSpec.hs
@@ -1,7 +1,11 @@
+{-# LANGUAGE QuasiQuotes #-}
 module Lift.ToolIntegration.ApplicableSpec where
 
 import Lift.ToolIntegration.Applicable
 import Test.Hspec
+import Text.RE.TDFA.Text
+import Mock.Project
+import Test.HMock
 import Relude
 
 spec :: Spec
@@ -15,7 +19,30 @@ spec = do
   describe "Determining if a given repository is applicable" $ do
     it "should always be applicable when configured as such" $
       determineApplicability AlwaysApplicable `shouldReturn` Applicable
-    it "should be applicable if the repository has the expected file" $ do
-      determineApplicability (ApplicableIfFileIsPresent "Cargo.toml") `shouldReturn` Applicable
-    it "should not be applicable if the repository lacks the expected file" $ do
-      determineApplicability (ApplicableIfFileIsPresent "Cargo.toml") `shouldReturn` Applicable
+    it "should be applicable if the repository has the expected file" $
+      ["Cargo.toml", "Cargo.lock", "src/main.rs"] `inTheProjectShouldBe` Applicable
+    it "should be applicable if the repository has the expected file in a subfolder" $
+      ["rust/Cargo.toml", "rust/Cargo.lock", "rust/src/main.rs"] `inTheProjectShouldBe` Applicable
+    it "should not be applicable if the repository lacks the expected file" $
+      ["build.gradle", "src/main/java/biz/haha/Factory.java"] `inTheProjectShouldBe` NotApplicable
+  describe "Determining if any of multiple conditions are applicable" $ do
+    it "should not be applicable if none of the conditions are applicable" $
+      applicabilityScenario (MultipleConditions (ApplicableIfFileIsPresent buildGradle :| [ApplicableIfFileIsPresent cargoToml])) NotApplicable  []
+    it "should be applicable if any condition is applicable" $
+      applicabilityScenario (MultipleConditions (AlwaysApplicable :| [ApplicableIfFileIsPresent cargoToml])) Applicable []
+
+inTheProjectShouldBe :: [Text] -> Applicability -> IO ()
+inTheProjectShouldBe = flip $ applicabilityScenario (ApplicableIfFileIsPresent cargoToml)
+
+applicabilityScenario :: ApplicabilityCondition -> Applicability -> [Text] -> IO ()
+applicabilityScenario condition expectedApplicability files = runMockT $ do
+  expectAny $ ListFiles |-> files
+  applicability <- determineApplicability condition
+  liftIO $ do
+    applicability `shouldBe` expectedApplicability
+
+cargoToml :: RE
+cargoToml = [re|Cargo\.toml|]
+
+buildGradle :: RE
+buildGradle = [re|build\.gradle|]

--- a/test/Lift/ToolIntegration/ProjectSpec.hs
+++ b/test/Lift/ToolIntegration/ProjectSpec.hs
@@ -1,0 +1,32 @@
+module Lift.ToolIntegration.ProjectSpec where
+
+import Lift.ToolIntegration.Project
+import GHC.IO (bracket)
+import Test.Hspec
+import System.Directory (createDirectory, removeDirectoryRecursive)
+import System.IO.Temp (createTempDirectory)
+import Relude
+
+spec :: Spec
+spec = do
+  describe "MonadProject" $
+    around withTempFiles $
+      describe "listFiles" $ do
+        it "should list all files in a project" $ \folder -> do
+          writeFile (toString folder <> "/topLevelFile.txt") ""
+          createDirectory (toString folder <> "/folder/")
+          writeFile (toString folder <> "/folder/secondLevelFile.log") ""
+          runProject folder `shouldReturn` ["topLevelFile.txt", "folder/secondLevelFile.log"]
+
+runProject :: Text -> IO [Text]
+runProject folder = let project = ProjectContext { projectRoot = folder }
+                    in usingReaderT project listFiles
+
+withTempFiles :: (Text -> IO ()) -> IO ()
+withTempFiles = bracket createFiles deleteFiles
+
+createFiles :: IO Text
+createFiles = toText <$> createTempDirectory "/tmp/" "lift-tools-framework-project-spec"
+
+deleteFiles :: Text -> IO ()
+deleteFiles = removeDirectoryRecursive . toString

--- a/test/Mock/Project.hs
+++ b/test/Mock/Project.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TemplateHaskell       #-}
+{-# OPTIONS_GHC -Wno-orphans       #-}
+module Mock.Project where
+
+import Lift.ToolIntegration.Project
+
+import Test.HMock
+
+makeMockable ''MonadProject
+

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -5,6 +5,7 @@ import Relude
 
 import qualified Lift.ToolIntegrationSpec as TISpec
 import qualified Lift.ToolIntegration.ApplicableSpec as AS
+import qualified Lift.ToolIntegration.ProjectSpec as PS
 
 main :: IO ()
 main = hspec spec
@@ -13,3 +14,4 @@ spec :: Spec
 spec = do
   describe "Lift.ToolIntegration" TISpec.spec
   describe "Lift.ToolIntegration.Applicable" AS.spec
+  describe "Lift.ToolIntegration.Project" PS.spec


### PR DESCRIPTION
Actionability
-------------
Add the ability to use a regular expression to determine if the project is
applicable if any file in the project matches the regular expression.
Add the ability to combine multiple applicability conditions.

Project
-------
Add a MonadProject abstraction that manages listing files in the project.
Create a ProjectContext that stores the project folder we get from Lift and
implement MonadProject on a ReaderT instance with a ProjectContext.
Add an allowed-orphans implementation of MonadProject via HMock in the test package.