### PR TITLE
Wire up applicability and fix bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # Lift Tools Framework
+

--- a/example/Main.hs
+++ b/example/Main.hs
@@ -1,8 +1,14 @@
+{-# LANGUAGE QuasiQuotes #-}
 module Main where
 
-import Lift.ToolIntegration (runToolMain)
+import Lift.ToolIntegration
+import Lift.ToolIntegration.Applicable.Regex
 import Relude
 
+application :: ToolApplication
+application = ToolApplication
+  { applicabilityCondition = ApplicableIfFileIsPresent [re|Cargo\.toml|]
+  }
 
 main :: IO ()
-main = runToolMain
+main = runToolMain application

--- a/lift-tools-framework.cabal
+++ b/lift-tools-framework.cabal
@@ -19,6 +19,7 @@ extra-source-files: README.md
 library
     exposed-modules:    Lift.ToolIntegration
                         Lift.ToolIntegration.Applicable
+                        Lift.ToolIntegration.Applicable.Regex
                         Lift.ToolIntegration.Cli
                         Lift.ToolIntegration.Project
                         Lift.ToolIntegration.ToolResults

--- a/src/Lift/ToolIntegration.hs
+++ b/src/Lift/ToolIntegration.hs
@@ -1,37 +1,49 @@
 {-# LANGUAGE RecordWildCards #-}
 module Lift.ToolIntegration
   ( module Lift.ToolIntegration.Applicable
+  , module Lift.ToolIntegration.Project
   , module Lift.ToolIntegration.ToolResults
+  , ToolApplication(..)
   , runToolMain
   ) where
 
 import           Data.Aeson
 import           Lift.ToolIntegration.Applicable
 import           Lift.ToolIntegration.Cli
+import           Lift.ToolIntegration.Project
 import           Lift.ToolIntegration.ToolResults
 import           Options.Applicative
 import qualified Data.Text.IO as T
 import           Relude
 
+-- | The configuration for your Haskell application
+data ToolApplication = ToolApplication
+  { applicabilityCondition :: ApplicabilityCondition
+  }
+
 -- | The entry-point for your Haskell application
-runToolMain :: IO ()
-runToolMain = execParser application >>= runTool
+runToolMain :: ToolApplication -> IO ()
+runToolMain toolApplication = execParser application >>= runTool toolApplication
 
-runTool :: Cli -> IO ()
-runTool Cli{..} = do
-  case cliAction of
-    CheckIfApplicable -> applicable
-    OutputApiVersion -> version
-    Run -> run
+runTool :: ToolApplication -> Cli -> IO ()
+runTool ToolApplication{..} Cli{..} = do
+  let projectContext = ProjectContext { projectRoot = projectFolder }
+  usingReaderT projectContext $ do
+    case cliAction of
+      CheckIfApplicable -> applicable applicabilityCondition
+      OutputApiVersion -> version
+      Run -> run
 
-applicable :: IO ()
-applicable = outputJson True
+applicable :: (MonadProject m, MonadIO m) => ApplicabilityCondition -> m ()
+applicable applicabilityCondition = do
+  response <- toApiResponse <$> determineApplicability applicabilityCondition
+  outputJson response
 
-version :: IO ()
+version :: (MonadIO m) => m ()
 version = outputJson (1 :: Int)
 
-run :: IO ()
+run :: (MonadIO m) => m ()
 run = outputJson ([] :: [ToolResult])
 
-outputJson :: (ToJSON a) => a -> IO ()
-outputJson = T.putStrLn . decodeUtf8 . encode
+outputJson :: (ToJSON a, MonadIO m) => a -> m ()
+outputJson = liftIO . T.putStrLn . decodeUtf8 . encode

--- a/src/Lift/ToolIntegration/Applicable/Regex.hs
+++ b/src/Lift/ToolIntegration/Applicable/Regex.hs
@@ -1,0 +1,5 @@
+module Lift.ToolIntegration.Applicable.Regex
+  ( module Text.RE.TDFA.Text
+  ) where
+
+import Text.RE.TDFA.Text

--- a/src/Lift/ToolIntegration/Project.hs
+++ b/src/Lift/ToolIntegration/Project.hs
@@ -11,9 +11,6 @@ import Relude
 class (Monad m) => MonadProject m where
   listFiles :: m [Text]
 
-instance MonadProject IO where
-  listFiles = error "TODO: implement"
-
 data ProjectContext = ProjectContext
   { projectRoot :: Text
   }
@@ -27,7 +24,6 @@ instance (MonadIO m) => MonadProject (ReaderT ProjectContext m) where
 
 listAllFiles :: (MonadIO m) => String -> m [String]
 listAllFiles folder = do
-  liftIO $ putStrLn ("listing: " <> folder)
   contents <- liftIO $ listDirectory (toString folder)
   (folders, files) <- liftIO $ partitionFiles (mappend (folder <> "/") <$> contents)
   subFiles <- join <$> traverse listAllFiles folders

--- a/test/Lift/ToolIntegration/ApplicableSpec.hs
+++ b/test/Lift/ToolIntegration/ApplicableSpec.hs
@@ -16,15 +16,17 @@ spec = do
     it "should be applicable if any sub-check is applicable" $ do
       (Applicable <> NotApplicable) `shouldBe` Applicable
       (NotApplicable <> Applicable) `shouldBe` Applicable
+
   describe "Determining if a given repository is applicable" $ do
     it "should always be applicable when configured as such" $
-      determineApplicability AlwaysApplicable `shouldReturn` Applicable
+      applicabilityScenario AlwaysApplicable Applicable []
     it "should be applicable if the repository has the expected file" $
       ["Cargo.toml", "Cargo.lock", "src/main.rs"] `inTheProjectShouldBe` Applicable
     it "should be applicable if the repository has the expected file in a subfolder" $
       ["rust/Cargo.toml", "rust/Cargo.lock", "rust/src/main.rs"] `inTheProjectShouldBe` Applicable
     it "should not be applicable if the repository lacks the expected file" $
       ["build.gradle", "src/main/java/biz/haha/Factory.java"] `inTheProjectShouldBe` NotApplicable
+
   describe "Determining if any of multiple conditions are applicable" $ do
     it "should not be applicable if none of the conditions are applicable" $
       applicabilityScenario (MultipleConditions (ApplicableIfFileIsPresent buildGradle :| [ApplicableIfFileIsPresent cargoToml])) NotApplicable  []


### PR DESCRIPTION
The application now requires a configuration that includes an applicability
condition. The example is updated to search for rust cargo projects.

Export the regex library's types that we use for applicability for convenience.

Remove an invalid "MonadProject IO" and fix the test that accidentally depended
on it.

Remove debugging print statements.