### PR TITLE
Implement Run functionality for a process

### DIFF
--- a/example/Main.hs
+++ b/example/Main.hs
@@ -1,13 +1,51 @@
-{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE DeriveAnyClass  #-}
+{-# LANGUAGE DeriveGeneric   #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE QuasiQuotes     #-}
 module Main where
 
+import Data.Aeson
 import Lift.ToolIntegration
 import Lift.ToolIntegration.Applicable.Regex
 import Relude
 
-application :: ToolApplication
-application = ToolApplication
-  { applicabilityCondition = ApplicableIfFileIsPresent [re|Cargo\.toml|]
+application :: ProjectContext -> ToolApplication
+application ProjectContext{..} = ToolApplication
+  { applicabilityCondition = ApplicableIfFileIsPresent [re|tsconfig\.json|]
+  , runTemplate = RunProcess
+    { processName = "npx"
+    , processArgs = [ "tslint", "--force", "--format", "json", "--project", projectRoot]
+    , processEnv = [("PATH", "/usr/bin/:./node_modules/.bin")]
+    , outputToToolResults = processOutput
+    }
+  }
+
+data TsLintIssue = TsLintIssue
+  { failure :: Text
+  , name :: Text
+  , ruleName :: Text
+  , startPosition :: Position
+  } deriving (Generic, FromJSON)
+
+data Position = Position
+  { position :: Int
+  } deriving (Generic, FromJSON)
+
+processOutput :: Text -> [ToolResult]
+processOutput output = let
+  decoded = eitherDecode $ encodeUtf8 output
+  in
+    case decoded of
+      Left e -> error (toText e)
+      Right issues -> toToolResult <$> issues
+
+toToolResult :: TsLintIssue -> ToolResult
+toToolResult TsLintIssue {..} = ToolResult
+  { toolResultType = ruleName
+  , message = failure
+  , file = name
+  , line = position startPosition
+  , detailsUrl = Nothing
   }
 
 main :: IO ()

--- a/lift-tools-framework.cabal
+++ b/lift-tools-framework.cabal
@@ -22,6 +22,7 @@ library
                         Lift.ToolIntegration.Applicable.Regex
                         Lift.ToolIntegration.Cli
                         Lift.ToolIntegration.Project
+                        Lift.ToolIntegration.Run
                         Lift.ToolIntegration.ToolResults
     build-depends:      base ^>=4.14.1.0
                       , relude >= 1.0.0 && < 1.1
@@ -31,6 +32,7 @@ library
                       , HMock >= 0.3.0 && < 0.4
                       , optparse-applicative >= 0.16.1 && < 0.17
                       , regex >= 1.1.0 && < 1.2
+                      , typed-process >= 0.2.6 && < 0.3
     hs-source-dirs:     src
     default-language:   Haskell2010
     ghc-options:        -threaded -Wall -Werror -rtsopts
@@ -43,6 +45,7 @@ test-suite lift-tools-framework-tests
     other-modules:      Lift.ToolIntegrationSpec
                         Lift.ToolIntegration.ApplicableSpec
                         Lift.ToolIntegration.ProjectSpec
+                        Lift.ToolIntegration.RunSpec
                         Mock.Project
     build-depends:      base ^>=4.14.1.0
                       , lift-tools-framework
@@ -66,7 +69,7 @@ executable lift-tools-framework-example
     build-depends:      base ^>=4.14.1.0
                       , lift-tools-framework
                       , relude >= 1.0.0 && < 1.1
-                      , optparse-applicative >= 0.16.1 && < 0.17
+                      , aeson >= 1.5.6 && < 1.6
     hs-source-dirs:     example
     default-language:   Haskell2010
     ghc-options:        -threaded -Wall -Werror -rtsopts

--- a/src/Lift/ToolIntegration/Run.hs
+++ b/src/Lift/ToolIntegration/Run.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE RecordWildCards #-}
+module Lift.ToolIntegration.Run
+  ( OutputTranslator
+  , RunTemplate(..)
+  , executeTemplate
+  ) where
+
+import Lift.ToolIntegration.Project
+import Lift.ToolIntegration.ToolResults
+import System.FilePath.Posix (makeRelative)
+
+import Relude
+
+type OutputTranslator
+  =  Text -- ^ The output from executing the process
+  -> [ToolResult]
+
+data RunTemplate
+  = RunProcess
+    { processName :: Text
+    , processArgs :: [Text]
+    , processEnv :: [(Text, Text)]
+    , outputToToolResults :: OutputTranslator
+    }
+
+executeTemplate :: (MonadProject m) => RunTemplate -> m [ToolResult]
+executeTemplate RunProcess {..} = do
+  projectRoot <- getProjectRoot
+  result <- runCommand processName processArgs processEnv
+  case result of
+    Right r -> pure $ makeFilePathRelative projectRoot <$> outputToToolResults r
+    Left _ -> pure [] -- TODO: log errors
+
+makeFilePathRelative :: Text -> ToolResult -> ToolResult
+makeFilePathRelative projectRoot ToolResult {..} = let f = toText $ makeRelative (toString projectRoot) (toString file)
+  in ToolResult
+    { file = f
+    , ..
+    }

--- a/test/Lift/ToolIntegration/RunSpec.hs
+++ b/test/Lift/ToolIntegration/RunSpec.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE RecordWildCards #-}
+module Lift.ToolIntegration.RunSpec where
+
+import Lift.ToolIntegration.Project
+import Lift.ToolIntegration.Run
+import Lift.ToolIntegration.ToolResults
+import Test.Hspec
+import Mock.Project
+import Test.HMock
+import Relude
+
+spec :: Spec
+spec = do
+  describe "Run" $ do
+    it "should make paths relative" $ do
+      runPathScenario "/tmp/fake_root/folder/test.txt" "folder/test.txt"
+    it "should leave relative paths unchanged" $ do
+      runPathScenario "folder/test.txt" "folder/test.txt"
+    it "should call the function when the process returned successfully" $
+      runScenario
+        (Right "output")
+        (\o -> [ToolResult
+                   { toolResultType = "test"
+                   , message = o
+                   , file = "test.txt"
+                   , line = 1
+                   , detailsUrl = Nothing
+                   }])
+        [ToolResult
+          { toolResultType = "test"
+          , message = "output"
+          , file = "test.txt"
+          , line = 1
+          , detailsUrl = Nothing
+          }]
+    it "should not call the function when an error is returned" $
+      runScenario (Left $ RunFailed { code = 1, output = "failed", errorOutput = "failed" }) (\_ -> error "This should not have been called") []
+
+runScenario :: Either RunCommandError Text -> (Text -> [ToolResult]) -> [ToolResult] -> IO ()
+runScenario commandOutput fn expectedResult = runMockT $ do
+  expect $ GetProjectRoot |-> "/tmp/fake_root/"
+  expect $ RunCommand "fake" ["args"] [("fake", "env")] |-> commandOutput
+  result <- executeTemplate $ RunProcess
+    { processName = "fake"
+    , processArgs = ["args"]
+    , processEnv = [("fake", "env")]
+    , outputToToolResults = fn
+    }
+  liftIO $ do
+    result `shouldBe` expectedResult
+
+runPathScenario :: Text -> Text -> IO ()
+runPathScenario path expectedPath = runScenario
+  (Right "output")
+  (\o -> [ToolResult
+           { toolResultType = "test"
+           , message = o
+           , file = path
+           , line = 1
+           , detailsUrl = Nothing
+           }])
+  [ToolResult
+    { toolResultType = "test"
+    , message = "output"
+    , file = expectedPath
+    , line = 1
+    , detailsUrl = Nothing
+    }]

--- a/test/Lift/ToolIntegration/RunSpec.hs
+++ b/test/Lift/ToolIntegration/RunSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE RecordWildCards #-}
 module Lift.ToolIntegration.RunSpec where
 
 import Lift.ToolIntegration.Project

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -6,6 +6,7 @@ import Relude
 import qualified Lift.ToolIntegrationSpec as TISpec
 import qualified Lift.ToolIntegration.ApplicableSpec as AS
 import qualified Lift.ToolIntegration.ProjectSpec as PS
+import qualified Lift.ToolIntegration.RunSpec as RS
 
 main :: IO ()
 main = hspec spec
@@ -15,3 +16,4 @@ spec = do
   describe "Lift.ToolIntegration" TISpec.spec
   describe "Lift.ToolIntegration.Applicable" AS.spec
   describe "Lift.ToolIntegration.Project" PS.spec
+  describe "Lift.ToolIntegration.Run" RS.spec


### PR DESCRIPTION
Users can now construct tools that execute a process and use the output to
create tool results.
Update the runToolMain function to provide the context to the end user to use
when constructing the ToolApplication
Update the example to use npx to run tslint if a configuration is defined

Closes #3