### PR TITLE
Add the ability to run against the contents of files in the project

### DIFF
--- a/example/Main.hs
+++ b/example/Main.hs
@@ -6,7 +6,7 @@ module Main where
 
 import Data.Aeson
 import Lift.ToolIntegration
-import Lift.ToolIntegration.Applicable.Regex
+import Lift.ToolIntegration.Regex
 import Relude
 
 application :: ProjectContext -> ToolApplication

--- a/lift-tools-framework.cabal
+++ b/lift-tools-framework.cabal
@@ -19,9 +19,9 @@ extra-source-files: README.md
 library
     exposed-modules:    Lift.ToolIntegration
                         Lift.ToolIntegration.Applicable
-                        Lift.ToolIntegration.Applicable.Regex
                         Lift.ToolIntegration.Cli
                         Lift.ToolIntegration.Project
+                        Lift.ToolIntegration.Regex
                         Lift.ToolIntegration.Run
                         Lift.ToolIntegration.ToolResults
     build-depends:      base ^>=4.14.1.0

--- a/src/Lift/ToolIntegration/Regex.hs
+++ b/src/Lift/ToolIntegration/Regex.hs
@@ -1,4 +1,4 @@
-module Lift.ToolIntegration.Applicable.Regex
+module Lift.ToolIntegration.Regex
   ( module Text.RE.TDFA.Text
   ) where
 

--- a/test/Lift/ToolIntegration/ProjectSpec.hs
+++ b/test/Lift/ToolIntegration/ProjectSpec.hs
@@ -17,6 +17,12 @@ spec = do
           createDirectory (toString folder <> "/folder/")
           writeFile (toString folder <> "/folder/secondLevelFile.log") ""
           listFilesInProject folder `shouldReturn` ["topLevelFile.txt", "folder/secondLevelFile.log"]
+      describe "contentsOfFile" $ do
+        it "should read the contents of a file that exists" $ \folder -> do
+          writeFile (toString folder <> "/contents.txt") "content"
+          contentsOfFileInProject folder "contents.txt" `shouldReturn` "content"
+        it "should fail to read the contents of a file that does not exist" $ \folder -> do
+          contentsOfFileInProject folder "contents.txt" `shouldThrow` anyException
       describe "runCommand" $ do
         it "should execute a process with arguments" $ \folder -> do
           runCommandInProject "echo" ["Hello world!"] [] folder `shouldReturn` (Right "Hello world!\n")
@@ -28,6 +34,10 @@ spec = do
 listFilesInProject :: Text -> IO [Text]
 listFilesInProject folder = let project = ProjectContext { projectRoot = folder }
                     in usingReaderT project listFiles
+
+contentsOfFileInProject :: Text -> Text -> IO Text
+contentsOfFileInProject folder file = let project = ProjectContext { projectRoot = folder }
+                    in usingReaderT project (contentsOfFile file)
 
 runCommandInProject :: Text -> [Text] -> [(Text, Text)] -> Text -> IO (Either RunCommandError Text)
 runCommandInProject exe args env folder = let project = ProjectContext { projectRoot = folder }

--- a/test/Lift/ToolIntegration/RunSpec.hs
+++ b/test/Lift/ToolIntegration/RunSpec.hs
@@ -1,8 +1,11 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE QuasiQuotes     #-}
 module Lift.ToolIntegration.RunSpec where
 
 import Lift.ToolIntegration.Project
 import Lift.ToolIntegration.Run
 import Lift.ToolIntegration.ToolResults
+import Text.RE.TDFA.Text
 import Test.Hspec
 import Mock.Project
 import Test.HMock
@@ -11,32 +14,38 @@ import Relude
 spec :: Spec
 spec = do
   describe "Run" $ do
-    it "should make paths relative" $ do
-      runPathScenario "/tmp/fake_root/folder/test.txt" "folder/test.txt"
-    it "should leave relative paths unchanged" $ do
-      runPathScenario "folder/test.txt" "folder/test.txt"
-    it "should call the function when the process returned successfully" $
-      runScenario
-        (Right "output")
-        (\o -> [ToolResult
+    describe "process template" $ do
+      it "should make paths relative" $ do
+        runPathScenario "/tmp/fake_root/folder/test.txt" "folder/test.txt"
+      it "should leave relative paths unchanged" $ do
+        runPathScenario "folder/test.txt" "folder/test.txt"
+      it "should call the function when the process returned successfully" $
+        runProcessScenario
+          (Right "output")
+          (\o -> [ToolResult
                    { toolResultType = "test"
                    , message = o
                    , file = "test.txt"
                    , line = 1
                    , detailsUrl = Nothing
                    }])
-        [ToolResult
-          { toolResultType = "test"
-          , message = "output"
-          , file = "test.txt"
-          , line = 1
-          , detailsUrl = Nothing
-          }]
-    it "should not call the function when an error is returned" $
-      runScenario (Left $ RunFailed { code = 1, output = "failed", errorOutput = "failed" }) (\_ -> error "This should not have been called") []
+          [ToolResult
+            { toolResultType = "test"
+            , message = "output"
+            , file = "test.txt"
+            , line = 1
+            , detailsUrl = Nothing
+            }]
+      it "should not call the function when an error is returned" $
+        runProcessScenario (Left $ RunFailed { code = 1, output = "failed", errorOutput = "failed" }) (\_ -> error "This should not have been called") []
+    describe "per file template" $ do
+      it "should exclude unrelated files"
+        runPerFileScenarioNoMatchingFiles
+      it "should produce tool results for a file"
+        runPerFileScenarioMatchingFiles
 
-runScenario :: Either RunCommandError Text -> (Text -> [ToolResult]) -> [ToolResult] -> IO ()
-runScenario commandOutput fn expectedResult = runMockT $ do
+runProcessScenario :: Either RunCommandError Text -> (Text -> [ToolResult]) -> [ToolResult] -> IO ()
+runProcessScenario commandOutput fn expectedResult = runMockT $ do
   expect $ GetProjectRoot |-> "/tmp/fake_root/"
   expect $ RunCommand "fake" ["args"] [("fake", "env")] |-> commandOutput
   result <- executeTemplate $ RunProcess
@@ -49,7 +58,7 @@ runScenario commandOutput fn expectedResult = runMockT $ do
     result `shouldBe` expectedResult
 
 runPathScenario :: Text -> Text -> IO ()
-runPathScenario path expectedPath = runScenario
+runPathScenario path expectedPath = runProcessScenario
   (Right "output")
   (\o -> [ToolResult
            { toolResultType = "test"
@@ -65,3 +74,40 @@ runPathScenario path expectedPath = runScenario
     , line = 1
     , detailsUrl = Nothing
     }]
+
+runPerFileScenarioNoMatchingFiles :: IO ()
+runPerFileScenarioNoMatchingFiles = runMockT $ do
+  expect $ GetProjectRoot |-> "/tmp/fake_root"
+  expect $ ListFiles |-> [f]
+  result <- executeTemplate RunPerFile { fileFilter = [re|.+\.rs|], fileContentsToToolResults  = error "This should not be called because no file should match the regex" }
+  liftIO $ do
+    result `shouldBe` []
+  where
+    f :: Text
+    f = "test/file.js"
+
+runPerFileScenarioMatchingFiles :: IO ()
+runPerFileScenarioMatchingFiles = runMockT $ do
+  expectAny $ GetProjectRoot |-> "/tmp/fake_root"
+  expect $ ListFiles |-> [f]
+  expect $ ContentsOfFile f |-> "file contents"
+  result <- executeTemplate RunPerFile { fileFilter = [re|.+\.rs|], fileContentsToToolResults  = toToolResults }
+  liftIO $ do
+    result `shouldBe` [ToolResult
+                        { toolResultType = "test"
+                        , message = "file contents"
+                        , file = f
+                        , line = 1
+                        , detailsUrl = Nothing
+                        }]
+  where
+    f :: Text
+    f = "test/file.rs"
+    toToolResults :: FileContents -> [ToolResult]
+    toToolResults FileContents {..} = [ToolResult
+                                        { toolResultType = "test"
+                                        , message = fileContent
+                                        , file = fileName
+                                        , line = 1
+                                        , detailsUrl = Nothing
+                                        }]


### PR DESCRIPTION
Allow the user to configure a tool to run for every file in a project that
matches a regular expression.

Move the regex library re-export since it's no longer just for applicability.

Resolves #4